### PR TITLE
add new feature: getFileAsync method to retrieve video files without downloading

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -3,6 +3,26 @@ import { YtDlp } from './src/index';
 
 const ytdlp = new YtDlp();
 
+async function getVideoFile() {
+  try {
+    const videoFile = await ytdlp.getFileAsync(
+      'https://www.youtube.com/watch?v=_AL4IwHuHlY',
+      {
+        onProgress: (progress) => {
+          console.log(progress);
+        },
+      }
+    );
+
+    console.log('Video File:', {
+      name: videoFile.name,
+      type: videoFile.type,
+      size: videoFile.size,
+    });
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
 async function downloadVideo() {
   try {
     const output = await ytdlp.downloadAsync(
@@ -63,6 +83,7 @@ ytdlp.downloadFFmpeg().then(async () => {
     await downloadVideo();
     await streamVideo();
     await execVideo();
+    await getVideoFile();
   } catch (error) {
     console.log(error);
   }

--- a/readme.md
+++ b/readme.md
@@ -309,6 +309,45 @@ Downloads `ffmpeg` using a predefined method.
 await ytDlp.downloadFFmpeg();
 ```
 
+### `getFileAsync<F extends DownloadKeyWord>(url, options?): Promise<File>`
+
+Returns a `File` object containing the video/audio data without saving it to disk.
+
+#### Parameters:
+
+- `url`: The URL of the video.
+- `options` (optional): Additional options for getting the file:
+  - `format`: String | [Format Options](#format-for-download)
+  - `filename`: Custom filename for the resulting file
+  - `metadata`: Custom metadata for the file:
+    - `name`: File name
+    - `type`: MIME type
+    - `size`: File size in bytes
+  - `onProgress`: A callback function to track progress of downloading
+
+#### Returns:
+
+- `Promise<File>`: Resolves to a `File` object containing the video/audio data.
+
+#### Example:
+
+```typescript
+const file = await ytdlp.getFileAsync(
+  'https://www.youtube.com/watch?v=exampleVideoID',
+  {
+    format: {
+      filter: 'audioandvideo',
+      type: 'mp4',
+      quality: 'highest',
+    },
+    filename: 'custom-video.mp4',
+    onProgress: (progress) => {
+      console.log(progress);
+    },
+  }
+);
+```
+
 # Format Options
 
 ### `format` for Download

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,13 @@ import { spawn, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { Blob } from 'buffer';
 import {
   ArgsOptions,
   DownloadKeyWord,
   DownloadOptions,
+  FileMetadata,
+  GetFileOptions,
   PipeResponse,
   StreamKeyWord,
   StreamOptions,
@@ -305,6 +308,137 @@ export class YtDlp {
 
   public async downloadFFmpeg() {
     return downloadFFmpeg();
+  }
+
+  public async getFileAsync<F extends DownloadKeyWord>(
+    url: string,
+    options?: GetFileOptions<F> & {
+      onProgress?: (p: VideoProgress) => void;
+    }
+  ): Promise<File> {
+    const info = await this.getInfoAsync(url);
+    const { format, filename, metadata, onProgress, ...opt } = options || {};
+
+    // PassThrough stream to collect data
+    const passThrough = new PassThrough();
+    const chunks: Buffer[] = [];
+
+    passThrough.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+
+    const args = this.buildArgs(url, opt, !!onProgress, [
+      ...parseDownloadOptions(format),
+      '-o',
+      '-',
+    ]);
+
+    await this._executeAsync(
+      args,
+      (data) => {
+        if (onProgress) {
+          const progress = stringToProgress(data);
+          if (progress) {
+            onProgress(progress);
+          }
+        }
+      },
+      passThrough
+    );
+
+    const blob = new Blob(chunks, { type: this.getContentType(format) });
+
+    const defaultMetadata: FileMetadata = {
+      name: filename || `${info.title}.${this.getFileExtension(format)}`,
+      type: this.getContentType(format),
+      size: blob.size,
+      ...metadata,
+    };
+    return new File([Buffer.concat(chunks)], defaultMetadata.name, {
+      type: defaultMetadata.type,
+    });
+  }
+
+  private getContentType(
+    format?: DownloadOptions<DownloadKeyWord>['format']
+  ): string {
+    if (!format || typeof format === 'string') {
+      return 'video/mp4';
+    }
+
+    const { filter, type } = format as {
+      filter: DownloadKeyWord;
+      type?: string;
+    };
+
+    switch (filter) {
+      case 'videoonly':
+      case 'audioandvideo':
+        switch (type) {
+          case 'mp4':
+            return 'video/mp4';
+          case 'webm':
+            return 'video/webm';
+          default:
+            return 'video/mp4';
+        }
+      case 'audioonly':
+        switch (type) {
+          case 'aac':
+            return 'audio/aac';
+          case 'flac':
+            return 'audio/flac';
+          case 'mp3':
+            return 'audio/mpeg';
+          case 'm4a':
+            return 'audio/mp4';
+          case 'opus':
+            return 'audio/opus';
+          case 'vorbis':
+            return 'audio/vorbis';
+          case 'wav':
+            return 'audio/wav';
+          case 'alac':
+            return 'audio/mp4';
+          default:
+            return 'audio/mpeg';
+        }
+      case 'mergevideo':
+        switch (type) {
+          case 'webm':
+            return 'video/webm';
+          case 'mkv':
+            return 'video/x-matroska';
+          case 'ogg':
+            return 'video/ogg';
+          case 'flv':
+            return 'video/x-flv';
+          default:
+            return 'video/mp4';
+        }
+    }
+  }
+
+  private getFileExtension(
+    format?: DownloadOptions<DownloadKeyWord>['format']
+  ): string {
+    if (!format || typeof format === 'string') {
+      return 'mp4';
+    }
+
+    const { filter, type } = format as {
+      filter: DownloadKeyWord;
+      type?: string;
+    };
+
+    if (type) {
+      return type;
+    }
+
+    switch (filter) {
+      case 'audioonly':
+        return 'mp3';
+      default:
+        return 'mp4';
+    }
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -472,3 +472,15 @@ export type PipeResponse = {
     }
   ) => Promise<NodeJS.WritableStream>;
 };
+
+export interface FileMetadata {
+  name: string;
+  type: string;
+  size?: number;
+}
+
+export interface GetFileOptions<F extends DownloadKeyWord>
+  extends DownloadOptions<F> {
+  filename?: string;
+  metadata?: FileMetadata;
+}


### PR DESCRIPTION
While working on a personal project, I needed a function that could return a File object instead of downloading the file. So I built `getFileAsync`, which retrieves a **video/audio** file as a `File` object without downloading it. This functionality is useful for scenarios where users need direct access to the file without saving it locally.