### PR TITLE
Update macOS binary name

### DIFF
--- a/src/scripts/download.ts
+++ b/src/scripts/download.ts
@@ -17,8 +17,8 @@ const PLATFORM_MAPPINGS: Record<string, Record<string, string>> = {
     aarch64: 'yt-dlp_linux_aarch64',
   },
   darwin: {
-    x64: 'dlp_macos',
-    arm64: 'dlp_macos',
+    x64: 'yt-dlp_macos',
+    arm64: 'yt-dlp_macos',
   },
 };
 


### PR DESCRIPTION
See https://github.com/yt-dlp/yt-dlp/releases/tag/2025.03.31

Also please add some info to README how to skip download skip on npm install