### PR TITLE
Fix default macOS binary name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,10 +56,16 @@ export class YtDlp {
 
   // done
   private getDefaultBinaryPath(): string {
-    return path.join(
-      BIN_DIR,
-      os.platform() === 'win32' ? 'yt-dlp.exe' : 'yt-dlp'
-    );
+    const platform = os.platform();
+    let binaryName: string;
+    if (platform === 'win32') {
+      binaryName = 'yt-dlp.exe';
+    } else if (platform === 'darwin') {
+      binaryName = 'yt-dlp_macos';
+    } else {
+      binaryName = 'yt-dlp';
+    }
+    return path.join(BIN_DIR, binaryName);
   }
 
   // done


### PR DESCRIPTION
On macOS, the default yt-dlp binary cannot be found because the `getDefaultBinaryPath()` function currently returns `yt-dlp` as the binary name if the platform is darwin (eg macOS), but the download script uses [yt-dlp_macos](https://github.com/iqbal-rashed/ytdlp-nodejs/blob/dc5d822f48880aa89c24ae27a2062cad019589fc/src/scripts/download.ts#L19) as the default binary name.

This PR just updates the binary name used by `getDefaultBinaryPath()` to `yt-dlp_macos` if the platform is darwin.