### PR TITLE
Add format_note

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -467,6 +467,7 @@ export interface VideoThumbnail {
 
 export interface VideoFormat {
   format_id: string;
+  format_note?: string;
   ext: string;
   url: string;
   width?: number;


### PR DESCRIPTION
There is more fields that are in `VideoInfo` but they can be also in `VideoFormat`, but i'm too lazy and only adding quality label for my use case.