### PR TITLE
Fix big memory usage for `stream`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,8 @@ export class YtDlp {
       let stderrData = '';
 
       ytDlpProcess.stdout.on('data', (data) => {
+        // in `passThrough` case `data` is video bytes, don't collect it
+        if (passThrough) return;
         stdoutData += data.toString();
         onData?.(Buffer.from(data).toString());
       });


### PR DESCRIPTION
On my 512mb ram vps i'm getting out of heap crash in nodejs when streaming 30min+ videos, because `stdoutData` collects video bytes instead of progress lines there.