### PR TITLE
Expose promise in `stream`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -281,7 +281,7 @@ export class YtDlp {
 
     const passThrough = new PassThrough();
 
-    this._executeAsync(
+    const promise = this._executeAsync(
       args,
       (data) => {
         const progress = stringToProgress(data);
@@ -293,6 +293,7 @@ export class YtDlp {
     );
 
     return {
+      promise: promise,
       pipe: (destination: NodeJS.WritableStream, options?: { end?: boolean }) =>
         passThrough.pipe(destination, options),
       pipeAsync: (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -542,6 +542,7 @@ export interface FormatOptions<F extends FormatKeyWord>
 }
 
 export type PipeResponse = {
+  promise: Promise<string>;
   pipe: (
     destination: NodeJS.WritableStream,
     options?: {


### PR DESCRIPTION
See https://github.com/iqbal-rashed/ytdlp-nodejs/issues/29

This is not perfect because firstly `pipeAsync.then` will happen, and only then this new `promise.catch`. Maybe you know how to rethrow promise error into pipe, so promise exposing will not be required. You can test that age restricted video in issue without cookies.