### PR TITLE
Add missing quality value

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -508,7 +508,7 @@ type VideoQuality =
 
 type QualityOptions = {
   videoonly: VideoQuality;
-  audioonly: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+  audioonly: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
   audioandvideo: 'highest' | 'lowest';
   mergevideo: VideoQuality;
 };


### PR DESCRIPTION
quality for audio should be from 0 (best) to 10 (worst)
see: https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#post-processing-options