### PR TITLE
linux arm64 support

### DIFF
--- a/src/utils/ytdlp.ts
+++ b/src/utils/ytdlp.ts
@@ -15,6 +15,7 @@ const PLATFORM_MAPPINGS: Record<string, Record<string, string>> = {
     x64: 'yt-dlp',
     armv7l: 'yt-dlp_linux_armv7l',
     aarch64: 'yt-dlp_linux_aarch64',
+    arm64: 'yt-dlp',
   },
   darwin: {
     x64: 'yt-dlp_macos',


### PR DESCRIPTION
```
Failed to download yt-dlp: Error: No FFmpeg build available for linux arm64
```

Fixes: #50

linux in arm64 comes when using linux distro in termux or any alternative 