### PR TITLE
Fix ffmpeg being wrongly detected as not installed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ export class YtDlp {
       binaryProcess.on('exit', (code) => {
         binaryExists = code === 0;
         if (options?.ffmpeg) {
-          const ffmpegProcess = spawn(this.ffmpegPath!, ['--version']);
+          const ffmpegProcess = spawn(this.ffmpegPath!, ['-version']);
           ffmpegProcess.on('error', () => (ffmpegExists = false));
           ffmpegProcess.on('exit', (code) => {
             ffmpegExists = code === 0;
@@ -124,7 +124,7 @@ export class YtDlp {
       stdio: 'ignore',
     });
     const ffmpegResult = options?.ffmpeg
-      ? spawnSync(this.ffmpegPath!, ['--version'], { stdio: 'ignore' })
+      ? spawnSync(this.ffmpegPath!, ['-version'], { stdio: 'ignore' })
       : { status: 0 };
     return binaryResult.status === 0 && ffmpegResult.status === 0;
   }


### PR DESCRIPTION
When running ffmpeg with --version, it causes the following error:
Unrecognized option '-version'.
Error splitting the argument list: Option not found
Which triggers the .on('error'), as well as the exit status check. Instead, ffmpeg should be ran with -version.