### PR TITLE
fix: failure to listen for error events resulted in exceptions

### DIFF
--- a/src/builder/download-builder.ts
+++ b/src/builder/download-builder.ts
@@ -61,6 +61,19 @@ export class Download extends BaseBuilder {
   // Promise handling
   private resultPromise?: Promise<DownloadFinishResult>;
 
+  constructor(
+    url: string,
+    options?: {
+      binaryPath?: string;
+      ffmpegPath?: string;
+    },
+  ) {
+    super(url, options);
+
+    // If the error event in Node.js is not being monitored or causes an exception
+    this.on('error', () => {});
+  }
+
   /**
    * Add a typed event listener
    */


### PR DESCRIPTION
If error events are not monitored in NodeJS, an exception will occur during emit

Reproduction method:
- download an incorrect URL causing yt dlp to fail to run，promise will not receive a reject event normally